### PR TITLE
README.md: fix RWTH Aachen link

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Installation
 Information
 -----------
 
-Inspired by the [USGerman layout](http://hci.rwth-aachen.de/USGermanKeyboard)
+Inspired by the [USGerman layout](https://hci.rwth-aachen.de/usgermankeyboard)
 by Prof. Dr. Jan Borchers from RWTH Aachen, but working in OSX 10.6 Snow
 Leopard. Made from scratch with [Ukelele](http://scripts.sil.org/Ukelele).
 


### PR DESCRIPTION
https://hci.rwth-aachen.de/USGermanKeyboard is 404, https://hci.rwth-aachen.de/usgermankeyboard works